### PR TITLE
Improve caching when fetching games JSON data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@
  - Browsing videos by team/player
  - Search across the NBA videos database
 
-# By me a cofee
+# Buy me a coffee
 If you want to donate you can do it using this link down here
 https://www.paypal.com/donate/?hosted_button_id=NB4C25J6ED3ZE

--- a/resources/lib/games.py
+++ b/resources/lib/games.py
@@ -273,7 +273,7 @@ def BROWSE_DAYS(plugin, month, year, cal=False, **kwargs):
 
 
 @Route.register(content_type="videos")
-def BROWSE_GAMES(plugin, DATE=None, games=None):
+def BROWSE_GAMES(plugin, DATE=None, games=None, cache_max_age=0):
     if not DATE:
         DATE = nowWEST()
     headers = {'User-Agent': USER_AGENT}
@@ -291,7 +291,7 @@ def BROWSE_GAMES(plugin, DATE=None, games=None):
         resp = urlquick.get(
                                 todays_game_url,
                                 headers=headers,
-                                max_age=0
+                                max_age=cache_max_age
                             ).text.replace('var g_schedule=','')
         games = json.loads(resp)
     liz = None

--- a/resources/lib/games.py
+++ b/resources/lib/games.py
@@ -160,7 +160,8 @@ def BROWSE_GAMES_MENU(plugin):
     FAVORITE_TEAMS = get_profile_info()['FAVORITE_TEAMS']
     yield Listitem.from_dict(
                                 BROWSE_GAMES,
-                                bold('Live Games')
+                                bold('Live Games'),
+                                params = {'DATE': nowWEST()}
                             )
     if EN_CAL:
         yield Listitem.from_dict(

--- a/resources/lib/games.py
+++ b/resources/lib/games.py
@@ -267,7 +267,7 @@ def BROWSE_DAYS(plugin, month, year, cal=False, **kwargs):
             yield Listitem.from_dict(
                                         BROWSE_GAMES,
                                         bold(title),
-                                        params = {'DATE': day}
+                                        params = {'DATE': day, 'cache_max_age': 60 * 60}
                                     )
 
 
@@ -322,26 +322,26 @@ def BROWSE_MONTHS(plugin, year=None, team=None, cal=False):
             yield Listitem.from_dict(
                                         BROWSE_GAMES,
                                         bold('Last Night'),
-                                        params = {'DATE': day}
+                                        params = {'DATE': day, 'cache_max_age': 60 * 60}
                                     )
             day = DATE + datetime.timedelta(days=-2)
             yield Listitem.from_dict(
                                         BROWSE_GAMES,
                                         bold('Two Nights Ago'),
-                                        params = {'DATE': day}
+                                        params = {'DATE': day, 'cache_max_age': 60 * 60}
                                     )
         if cal:
             day = DATE + datetime.timedelta(days=+1)
             yield Listitem.from_dict(
                                         BROWSE_GAMES,
                                         bold('Tomorrow'),
-                                        params = {'DATE': day}
+                                        params = {'DATE': day, 'cache_max_age': 60 * 60}
                                     )
             day = DATE + datetime.timedelta(days=+2)
             yield Listitem.from_dict(
                                         BROWSE_GAMES,
                                         bold('In Two days'),
-                                        params = {'DATE': day}
+                                        params = {'DATE': day, 'cache_max_age': 60 * 60}
                                     )
             start_month = month
             month = 12


### PR DESCRIPTION
This PR basically does two things:

1. It uses `urlquick`'s built-in caching mechanism to avoid re-fetching JSON files for games data. The cache TTL is set to 0 for live games and 1 hour for everything else.
2. It fixes an issue where if the plugin remained in memory >24 hours or was used before/after midnight, live game results would be for the wrong day.

Fixes #15.